### PR TITLE
Fix error on bs build and make it more configurable

### DIFF
--- a/tasks/bootstrap_json2less.js
+++ b/tasks/bootstrap_json2less.js
@@ -17,8 +17,9 @@ module.exports = function(grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var shell = require('shelljs');
     var options = this.options({
-      dist: null, 
+      dist: null,
       bs_dir: null, //bootstrap directory. Leave blank for same folder
+      bs_tasks: ['dist'],
       varPrefix: '',// set to '@' if not included in config.json
       banner: '// DO NOT EDIT! CREATED/EDITED AUTOMATICALLY with grunt-bootstrap-json2less'
     });
@@ -57,12 +58,14 @@ module.exports = function(grunt) {
           grunt.log.ok('successfully copied: %s to: %s', file.dest, options.dist);
         }
         if (options.bs_dir) {
+          var dir = shell.pwd();
           shell.cd(options.bs_dir);
           //build new bootstrap files
-          if (shell.exec('grunt dist').code !== 0) {
+          if (shell.exec('grunt ' + options.bs_tasks.join(' ')).code !== 0) {
             shell.echo('Error: Bootstrap build failed');
             shell.exit(1);
-          }          
+          }
+          shell.cd(dir);
           grunt.log.ok('successfully built new bootstrap files in directory: %s', options.bs_dir);
         }
       });


### PR DESCRIPTION
After "shell.cd(options.bs_dir)" fails other grunt tasks. Also it's useful able to grunt boostap with custom options (tasks list), for example i run it with ['less:compileCore', 'autoprefixer:core', 'dist-js']
